### PR TITLE
Migrate to new publish plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.time.Duration
+
 buildscript {
     repositories {
         mavenCentral()
@@ -8,7 +10,8 @@ plugins {
     kotlin("jvm") version "1.7.10"
     kotlin("jupyter.api") version "0.11.0-134"
     id("maven-publish")
-    id("io.codearte.nexus-staging") version "0.22.0"
+    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+    id("org.jetbrains.dokka") version "1.7.10"
 }
 
 val ggdslVersion = "0.1.1-dev-11"
@@ -20,10 +23,29 @@ allprojects {
 
     group = "org.jetbrains.kotlinx"
     version = ggdslVersion
-    apply(plugin = "maven-publish")
     apply(plugin = "kotlin")
+    apply(plugin = "org.jetbrains.dokka")
 }
 
 subprojects {
     apply(from = project.rootProject.file("gradle/publish.gradle"))
+}
+
+val sonatypeUser: String = System.getenv("SONATYPE_USER") ?: ""
+val sonatypePassword: String = System.getenv("SONATYPE_PASSWORD") ?: ""
+
+nexusPublishing {
+    packageGroup.set(project.group.toString())
+    repositories {
+        sonatype {
+            username.set(sonatypeUser)
+            password.set(sonatypePassword)
+            repositoryDescription.set("ggdsl staging repository, version: $version")
+        }
+    }
+
+    transitionCheckOptions {
+        maxRetries.set(100)
+        delayBetween.set(Duration.ofSeconds(5))
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ buildscript {
 }
 
 plugins {
-    kotlin("jvm") version "1.6.0"
+    kotlin("jvm") version "1.7.10"
     kotlin("jupyter.api") version "0.11.0-134"
     id("maven-publish")
     id("io.codearte.nexus-staging") version "0.22.0"

--- a/ggdsl-api/build.gradle.kts
+++ b/ggdsl-api/build.gradle.kts
@@ -1,9 +1,6 @@
 plugins {
     kotlin("jvm")
-    id("org.jetbrains.dokka") version "1.6.21"
     kotlin("jupyter.api")
-    id("maven-publish")
-
 }
 
 repositories {

--- a/ggdsl-dataframe/build.gradle.kts
+++ b/ggdsl-dataframe/build.gradle.kts
@@ -1,8 +1,6 @@
 plugins {
     kotlin("jvm")
-    id("org.jetbrains.dokka") version "1.6.21"
     kotlin("jupyter.api")
-    id("maven-publish")
 
 }
 

--- a/ggdsl-echarts/build.gradle.kts
+++ b/ggdsl-echarts/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     id("org.jetbrains.dokka") version "1.6.21"
     kotlin("plugin.serialization") version "1.6.0"
     kotlin("jupyter.api")
-    id("maven-publish")
 }
 
 repositories {

--- a/ggdsl-lets-plot/build.gradle.kts
+++ b/ggdsl-lets-plot/build.gradle.kts
@@ -1,8 +1,6 @@
 plugins {
     kotlin("jvm")
-    id("org.jetbrains.dokka") version "1.6.21"
     kotlin("jupyter.api")
-    id("maven-publish")
 }
 
 repositories {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -14,13 +14,6 @@ task javadocJar(type: Jar) {
     from javadoc
 }
 
-nexusStaging {
-    username sonatypeUser
-    password sonatypePassword
-    packageGroup project.group.toString()
-    repositoryDescription "ggdsl staging repository, version: $version"
-}
-
 publishing {
     publications {
         maven(MavenPublication) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
* update kotlin version
* update gradle version
* migrate from deprecated `nexus-staging` to `publish-plugin`
* cleanup plugins [maven-publish, dokka]

With the new plugin, you need to change the called gradle tasks for publish